### PR TITLE
Settle funding fees

### DIFF
--- a/synthetics-stats/package.json
+++ b/synthetics-stats/package.json
@@ -4,10 +4,11 @@
   "scripts": {
     "codegen": "graph codegen ./subgraph-fuji.yaml",
     "build": "graph build ./subgraph-fuji.yaml",
-    "deploy-satsuma:fuji": "graph deploy synthetics-fuji-stats ./subgraph-fuji.yaml --version-label $(git rev-parse --abbrev-ref HEAD)-$(date '+%y%m%d%H%M%S')-$(git rev-parse --short HEAD) --node https://app.satsuma.xyz/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $(cat .satsuma_token)",
-    "deploy-satsuma:goerli": "graph deploy synthetics-goerli-stats ./subgraph-goerli.yaml --version-label $(git rev-parse --abbrev-ref HEAD)-$(date '+%y%m%d%H%M%S')-$(git rev-parse --short HEAD) --node https://app.satsuma.xyz/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $(cat .satsuma_token)",
-    "deploy-satsuma:arbitrum": "graph deploy synthetics-arbitrum-stats ./subgraph-arbitrum.yaml --version-label $(git rev-parse --abbrev-ref HEAD)-$(date '+%y%m%d%H%M%S')-$(git rev-parse --short HEAD) --node https://app.satsuma.xyz/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $(cat .satsuma_token)",
-    "deploy-satsuma:avalanche": "graph deploy synthetics-avalanche-stats ./subgraph-avalanche.yaml --version-label $(git rev-parse --abbrev-ref HEAD)-$(date '+%y%m%d%H%M%S')-$(git rev-parse --short HEAD) --node https://app.satsuma.xyz/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $(cat .satsuma_token)"
+    "deploy-satsuma:fuji": "graph deploy synthetics-fuji-stats ./subgraph-fuji.yaml --version-label $(git rev-parse --abbrev-ref HEAD)-$(date '+%y%m%d%H%M%S')-$(git rev-parse --short HEAD) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $(cat .satsuma_token)",
+    "deploy-satsuma:goerli": "graph deploy synthetics-goerli-stats ./subgraph-goerli.yaml --version-label $(git rev-parse --abbrev-ref HEAD)-$(date '+%y%m%d%H%M%S')-$(git rev-parse --short HEAD) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $(cat .satsuma_token)",
+    "deploy-satsuma:arbitrum": "graph deploy synthetics-arbitrum-stats ./subgraph-arbitrum.yaml --version-label $(git rev-parse --abbrev-ref HEAD)-$(date '+%y%m%d%H%M%S')-$(git rev-parse --short HEAD) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $(cat .satsuma_token)",
+    "deploy-satsuma:avalanche": "graph deploy synthetics-avalanche-stats ./subgraph-avalanche.yaml --version-label $(git rev-parse --abbrev-ref HEAD)-$(date '+%y%m%d%H%M%S')-$(git rev-parse --short HEAD) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $(cat .satsuma_token)",
+    "deploy-satsuma:all": "yarn deploy-satsuma:fuji && yarn deploy-satsuma:goerli && yarn deploy-satsuma:arbitrum && yarn deploy-satsuma:avalanche"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.21.1",

--- a/synthetics-stats/schema.graphql
+++ b/synthetics-stats/schema.graphql
@@ -274,8 +274,6 @@ type ClaimAction @entity {
   tokenAddresses: [String!]!
   amounts: [BigInt!]!
   isLongOrders: [Boolean!]!
-
-  transactionIds: [String!]!
   transaction: Transaction!
 }
 

--- a/synthetics-stats/schema.graphql
+++ b/synthetics-stats/schema.graphql
@@ -262,7 +262,6 @@ type ClaimAction @entity {
   marketAddresses: [String!]!
   tokenAddresses: [String!]!
   amounts: [BigInt!]!
-  orders: [String!]
 
   transaction: Transaction!
 }
@@ -271,6 +270,7 @@ type ClaimRef @entity(immutable: true) {
   # order.id
   id: ID!
   claimIdPrefix: String!
+  orders: [String!]
 }
 
 type PoolAmountUpdate @entity(immutable: true) {

--- a/synthetics-stats/schema.graphql
+++ b/synthetics-stats/schema.graphql
@@ -262,7 +262,9 @@ type ClaimAction @entity {
   marketAddresses: [String!]!
   tokenAddresses: [String!]!
   amounts: [BigInt!]!
+  isLongOrders: [Boolean!]!
 
+  transactionIds: [String!]!
   transaction: Transaction!
 }
 
@@ -270,7 +272,7 @@ type ClaimRef @entity(immutable: true) {
   # order.id
   id: ID!
   claimIdPrefix: String!
-  orders: [String!]
+  orders: [Order!]!
 }
 
 type PoolAmountUpdate @entity(immutable: true) {
@@ -285,9 +287,9 @@ type PoolAmountUpdate @entity(immutable: true) {
 type ClaimableFundingFeeInfo @entity(immutable: true) {
   # transactionHash:account
   id: ID!
-  marketAddress: String!
-  nextValue: BigInt!
-  delta: BigInt!
+  marketAddresses: [String!]!
+  tokenAddresses: [String!]!
+  amounts: [BigInt!]!
 }
 
 type Transaction @entity {

--- a/synthetics-stats/schema.graphql
+++ b/synthetics-stats/schema.graphql
@@ -268,11 +268,9 @@ type ClaimAction @entity {
   transaction: Transaction!
 }
 
-type ClaimRef @entity(immutable: true) {
+type ClaimRef @entity {
   # order.id
   id: ID!
-  claimIdPrefix: String!
-  orders: [Order!]!
 }
 
 type PoolAmountUpdate @entity(immutable: true) {

--- a/synthetics-stats/schema.graphql
+++ b/synthetics-stats/schema.graphql
@@ -13,9 +13,12 @@ enum TradeActionType {
   OrderUpdated
 }
 
-enum ClaimCollateralActionType {
+enum ClaimActionType {
   ClaimPriceImpact
   ClaimFunding
+  SettleFundingFeeCreated
+  SettleFundingFeeExecuted
+  SettleFundingFeeCancelled
 }
 
 type AffiliateRewardUpdate @entity(immutable: true) {
@@ -242,13 +245,32 @@ type TradeAction @entity(immutable: true) {
 type ClaimCollateralAction @entity(immutable: true) {
   # transactionHash:account:eventName
   id: ID!
-  eventName: ClaimCollateralActionType!
+  eventName: ClaimActionType!
   account: String!
   marketAddresses: [String!]!
   tokenAddresses: [String!]!
   amounts: [BigInt!]!
 
   transaction: Transaction!
+}
+
+type ClaimAction @entity {
+  # transactionHash:account:eventName
+  id: ID!
+  eventName: ClaimActionType!
+  account: String!
+  marketAddresses: [String!]!
+  tokenAddresses: [String!]!
+  amounts: [BigInt!]!
+  orders: [String!]
+
+  transaction: Transaction!
+}
+
+type ClaimRef @entity(immutable: true) {
+  # order.id
+  id: ID!
+  claimIdPrefix: String!
 }
 
 type PoolAmountUpdate @entity(immutable: true) {
@@ -258,6 +280,14 @@ type PoolAmountUpdate @entity(immutable: true) {
   delta: BigInt!
   nextValue: BigInt!
   transaction: Transaction!
+}
+
+type ClaimableFundingFeeInfo @entity(immutable: true) {
+  # transactionHash:account
+  id: ID!
+  marketAddress: String!
+  nextValue: BigInt!
+  delta: BigInt!
 }
 
 type Transaction @entity {

--- a/synthetics-stats/src/entities/claims.ts
+++ b/synthetics-stats/src/entities/claims.ts
@@ -1,21 +1,138 @@
-import { BigInt } from "@graphprotocol/graph-ts";
-import { ClaimCollateralAction, Transaction } from "../../generated/schema";
+import { BigInt, log } from "@graphprotocol/graph-ts";
+import {
+  ClaimAction,
+  ClaimCollateralAction,
+  ClaimRef,
+  ClaimableFundingFeeInfo,
+  Order,
+  Transaction,
+} from "../../generated/schema";
 import { EventData } from "../utils/eventData";
+import { orderTypes } from "./orders";
+
+export function handleFundingFeeCreatedClaimAction(
+  transaction: Transaction,
+  eventData: EventData
+): void {
+  let account = eventData.getAddressItemString("account")!;
+  let id = transaction.id + ":" + account + ":SettleFundingFeeCreated";
+  let claimAction = getOrCreateClaimAction(id);
+
+  addRequiredFieldsToClaimAction(
+    claimAction,
+    eventData,
+    transaction,
+    "SettleFundingFeeCreated"
+  );
+  enrichCreatedClaimAction(claimAction, eventData);
+
+  let key = eventData.getBytes32Item("key")!.toHexString();
+  let order = Order.load(key);
+
+  if (!order) throw new Error("Order not found");
+
+  let claimRef = getOrCreateClaimRef(order.id);
+  claimRef.claimIdPrefix = transaction.id + ":" + account;
+  claimRef.save();
+}
+
+export function handleFundingFeeExecutedClaimAction(
+  transaction: Transaction,
+  eventData: EventData
+): void {
+  let claimAction = getOrCreateExecutedClaimAction(transaction, eventData);
+  let claimRef = getClaimRef(eventData);
+  let claimActionCreated = ClaimAction.load(
+    claimRef.claimIdPrefix + ":SettleFundingFeeCreated"
+  );
+
+  if (!claimActionCreated) throw new Error("ClaimAction not found");
+
+  if (!claimActionCreated.orders || !claimActionCreated.orders.length)
+    throw new Error("Empty orders in claimActionCreated");
+
+  let orderId = eventData.getBytes32Item("key")!.toHexString();
+  let order = Order.load(orderId);
+
+  if (!order) throw new Error("Order not found");
+
+  copyClaimActionMarketByIndex(
+    claimActionCreated!,
+    claimAction!,
+    claimActionCreated.orders.indexOf(order.id)
+  );
+
+  let account = eventData.getAddressItemString("account")!;
+  let claimableFundingFeeInfo = ClaimableFundingFeeInfo.load(
+    transaction.id + ":" + account
+  );
+
+  if (!claimableFundingFeeInfo)
+    throw new Error("ClaimableFundingFeeInfo not found");
+
+  insertFundingFeeInfo(claimAction, claimableFundingFeeInfo!);
+  insertFundingFeeInfo(claimActionCreated!, claimableFundingFeeInfo!);
+}
 
 export function handleCollateralClaimAction(
   eventData: EventData,
   transaction: Transaction,
   eventName: string
-): ClaimCollateralAction {
+): void {
   let account = eventData.getAddressItemString("account")!;
-
   let id = transaction.id + ":" + account + ":" + eventName;
+  let claimCollateralAction = getOrCreateClaimCollateralAction(id);
+  let claimAction = getOrCreateClaimAction(id);
 
-  let claimAction = getOrCreateClaimCollateralAction(id);
+  addFieldsToCollateralLikeClaimAction(
+    claimAction,
+    eventData,
+    transaction,
+    eventName
+  );
+  addFieldsToCollateralLikeClaimAction(
+    claimCollateralAction as ClaimAction,
+    eventData,
+    transaction,
+    eventName
+  );
 
-  claimAction.eventName = eventName;
-  claimAction.account = account;
+  claimCollateralAction.save();
+  claimAction.save();
+}
 
+export function saveClaimableFundingFeeInfo(
+  eventData: EventData,
+  transaction: Transaction
+): ClaimableFundingFeeInfo {
+  let account = eventData.getAddressItemString("account")!;
+  let id = transaction.id + ":" + account;
+  let entity = ClaimableFundingFeeInfo.load(id);
+
+  if (!entity) {
+    entity = new ClaimableFundingFeeInfo(id);
+    entity.marketAddress = eventData.getAddressItemString("market")!;
+    entity.delta = eventData.getUintItem("delta")!;
+    entity.nextValue = eventData.getUintItem("nextValue")!;
+  }
+
+  entity.save();
+
+  return entity!;
+}
+
+function addFieldsToCollateralLikeClaimAction(
+  claimAction: ClaimAction,
+  eventData: EventData,
+  transaction: Transaction,
+  eventName: string
+): void {
+  addRequiredFieldsToClaimAction(
+    claimAction,
+    eventData,
+    transaction,
+    eventName
+  );
   let marketAddresses = claimAction.marketAddresses;
   marketAddresses.push(eventData.getAddressItemString("market")!);
   claimAction.marketAddresses = marketAddresses;
@@ -27,17 +144,112 @@ export function handleCollateralClaimAction(
   let amounts = claimAction.amounts;
   amounts.push(eventData.getUintItem("amount")!);
   claimAction.amounts = amounts;
+}
 
-  claimAction.transaction = transaction.id;
-
-  claimAction.save();
-
+function getOrCreateExecutedClaimAction(
+  transaction: Transaction,
+  eventData: EventData
+): ClaimAction {
+  let claimRef = getClaimRef(eventData);
+  let id = claimRef.claimIdPrefix + ":SettleFundingFeeExecuted";
+  let claimAction = getOrCreateClaimAction(id);
+  addRequiredFieldsToClaimAction(
+    claimAction,
+    eventData,
+    transaction,
+    "SettleFundingFeeCreated"
+  );
   return claimAction;
 }
 
-export function getOrCreateClaimCollateralAction(
-  id: string
-): ClaimCollateralAction {
+function addRequiredFieldsToClaimAction(
+  claimAction: ClaimAction,
+  eventData: EventData,
+  transaction: Transaction,
+  eventName: string
+): void {
+  let account = eventData.getAddressItemString("account")!;
+  claimAction.eventName = eventName;
+  claimAction.account = account;
+  claimAction.transaction = transaction.id;
+  claimAction.save();
+}
+
+function enrichCreatedClaimAction(
+  claimAction: ClaimAction,
+  eventData: EventData
+): void {
+  let marketAddresses = claimAction.marketAddresses;
+  let marketAddress = eventData.getAddressItemString("market")!;
+  marketAddresses.push(marketAddress);
+  claimAction.marketAddresses = marketAddresses;
+  claimAction.save();
+
+  let tokenAddresses = claimAction.tokenAddresses;
+  let token = eventData.getAddressItemString("initialCollateralToken")!;
+
+  tokenAddresses.push(token);
+  claimAction.tokenAddresses = tokenAddresses;
+
+  let orders = claimAction.orders || [];
+  orders.push(eventData.getBytes32Item("key")!.toHexString());
+  claimAction.orders = orders;
+
+  claimAction.save();
+}
+
+function insertFundingFeeInfo(
+  claimAction: ClaimAction,
+  claimableFundingFeeInfo: ClaimableFundingFeeInfo
+): void {
+  let marketAddresses = claimAction.marketAddresses;
+  let marketAddress = claimableFundingFeeInfo.marketAddress;
+  let index = marketAddresses.indexOf(marketAddress);
+
+  if (index !== -1) {
+    let amounts = claimAction.amounts;
+    amounts[index as i32] = claimableFundingFeeInfo.delta;
+
+    claimAction.amounts = amounts;
+  }
+  claimAction.save();
+}
+
+function copyClaimActionMarketByIndex(
+  from: ClaimAction,
+  to: ClaimAction,
+  index: i32
+): void {
+  if (index === -1) throw new Error("Order not found in orders");
+
+  let fromMarketAddresses = from.marketAddresses;
+  let fromTokenAddresses = from.tokenAddresses;
+  log.warning("fromMarketAddresses=[{}] ; index={} ; orders=[{}]", [
+    fromMarketAddresses.join(", "),
+    index.toString(),
+    from.orders!.join(", "),
+  ]);
+
+  let marketAddress = fromMarketAddresses[index as i32];
+  let tokenAddress = fromTokenAddresses[index as i32];
+
+  if (!marketAddress || !tokenAddress) {
+    throw new Error("marketAddress or tokenAddress is null");
+  }
+
+  let toMarketAddresses = to.marketAddresses;
+  let toTokenAddresses = to.tokenAddresses;
+
+  toMarketAddresses.push(marketAddress);
+  toTokenAddresses.push(tokenAddress);
+
+  to.marketAddresses = toMarketAddresses;
+  to.tokenAddresses = toTokenAddresses;
+
+  to.save();
+}
+
+function getOrCreateClaimCollateralAction(id: string): ClaimCollateralAction {
   let entity = ClaimCollateralAction.load(id);
 
   if (!entity) {
@@ -48,4 +260,48 @@ export function getOrCreateClaimCollateralAction(
   }
 
   return entity as ClaimCollateralAction;
+}
+
+function getOrCreateClaimAction(id: string): ClaimAction {
+  let entity = ClaimAction.load(id);
+
+  if (!entity) {
+    entity = new ClaimAction(id);
+    entity.marketAddresses = new Array<string>(0);
+    entity.tokenAddresses = new Array<string>(0);
+    entity.amounts = new Array<BigInt>(0);
+  }
+
+  return entity as ClaimAction;
+}
+
+export function isFundingFeeSettleOrder(order: Order): boolean {
+  return (
+    order.initialCollateralDeltaAmount.equals(BigInt.fromI32(1)) &&
+    order.sizeDeltaUsd.equals(BigInt.fromI32(0)) &&
+    order.orderType == orderTypes.get("MarketDecrease")
+  );
+}
+
+function getOrCreateClaimRef(orderId: string): ClaimRef {
+  let entity = ClaimRef.load(orderId);
+
+  if (!entity) {
+    entity = new ClaimRef(orderId);
+  }
+
+  return entity as ClaimRef;
+}
+
+function getClaimRef(eventData: EventData): ClaimRef {
+  let key = eventData.getBytes32Item("key")!.toHexString();
+  let order = Order.load(key);
+
+  if (!order) throw new Error("Order not found");
+
+  let claimRef = ClaimRef.load(order.id);
+
+  if (!claimRef) throw new Error("ClaimRef not found");
+
+  return claimRef!;
 }

--- a/synthetics-stats/src/entities/claims.ts
+++ b/synthetics-stats/src/entities/claims.ts
@@ -33,6 +33,9 @@ export function handleFundingFeeCreatedClaimAction(
 
   let claimRef = getOrCreateClaimRef(order.id);
   claimRef.claimIdPrefix = transaction.id + ":" + account;
+  let orders = claimRef.orders || [];
+  orders.push(eventData.getBytes32Item("key")!.toHexString());
+  claimRef.orders = orders;
   claimRef.save();
 }
 
@@ -52,8 +55,8 @@ export function handleFundingFeeExecutedClaimAction(
 
   if (!claimActionCreated) throw new Error("ClaimAction not found");
 
-  if (!claimActionCreated.orders || !claimActionCreated.orders.length)
-    throw new Error("Empty orders in claimActionCreated");
+  if (!claimRef.orders || !claimRef.orders.length)
+    throw new Error("Empty orders in claimRef");
 
   let orderId = eventData.getBytes32Item("key")!.toHexString();
   let order = Order.load(orderId);
@@ -63,7 +66,7 @@ export function handleFundingFeeExecutedClaimAction(
   copyClaimActionMarketByIndex(
     claimActionCreated!,
     claimAction!,
-    claimActionCreated.orders.indexOf(order.id)
+    claimRef.orders.indexOf(order.id)
   );
 
   let account = eventData.getAddressItemString("account")!;
@@ -120,8 +123,8 @@ export function handleFundingFeeCancelledClaimAction(
 
   if (!claimActionCreated) throw new Error("ClaimAction not found");
 
-  if (!claimActionCreated.orders || !claimActionCreated.orders.length)
-    throw new Error("Empty orders in claimActionCreated");
+  if (!claimRef.orders || !claimRef.orders.length)
+    throw new Error("Empty orders in claimRef");
 
   let orderId = eventData.getBytes32Item("key")!.toHexString();
   let order = Order.load(orderId);
@@ -131,7 +134,7 @@ export function handleFundingFeeCancelledClaimAction(
   copyClaimActionMarketByIndex(
     claimActionCreated!,
     claimAction!,
-    claimActionCreated.orders.indexOf(order.id)
+    claimRef.orders.indexOf(order.id)
   );
 }
 
@@ -226,10 +229,6 @@ function enrichCreatedClaimAction(
 
   tokenAddresses.push(token);
   claimAction.tokenAddresses = tokenAddresses;
-
-  let orders = claimAction.orders || [];
-  orders.push(eventData.getBytes32Item("key")!.toHexString());
-  claimAction.orders = orders;
 
   claimAction.save();
 }

--- a/synthetics-stats/src/entities/claims.ts
+++ b/synthetics-stats/src/entities/claims.ts
@@ -67,12 +67,7 @@ export function handleFundingFeeExecutedClaimAction(
   );
 
   if (!claimableFundingFeeInfo) {
-    log.warning("ClaimableFundingFeeInfo not found {}", [
-      claimableFundingFeeInfoId,
-    ]);
-    log.warning("Transaction {}", [transaction.id]);
-    log.warning("Order {}", [order.id]);
-    throw new Error("ClaimableFundingFeeInfo not found");
+    return;
   }
 
   insertFundingFeeInfo(claimAction, claimableFundingFeeInfo!);

--- a/synthetics-stats/src/entities/claims.ts
+++ b/synthetics-stats/src/entities/claims.ts
@@ -36,7 +36,7 @@ export function saveClaimActionOnOrderCreated(
 
   claimAction.save();
 
-  getOrCreateClaimRef(orderId);
+  createClaimRefIfNotExists(orderId);
 }
 
 export function saveClaimActionOnOrderCancelled(
@@ -239,13 +239,9 @@ export function isFundingFeeSettleOrder(order: Order): boolean {
   );
 }
 
-function getOrCreateClaimRef(orderId: string): ClaimRef {
-  let entity = ClaimRef.load(orderId);
-
-  if (!entity) {
-    entity = new ClaimRef(orderId);
+function createClaimRefIfNotExists(orderId: string): void {
+  if (!ClaimRef.load(orderId)) {
+    let entity = new ClaimRef(orderId);
     entity.save();
   }
-
-  return entity!;
 }

--- a/synthetics-stats/src/entities/claims.ts
+++ b/synthetics-stats/src/entities/claims.ts
@@ -61,12 +61,19 @@ export function handleFundingFeeExecutedClaimAction(
   if (!order) throw new Error("Order not found");
 
   let account = eventData.getAddressItemString("account")!;
+  let claimableFundingFeeInfoId = transaction.id + ":" + account;
   let claimableFundingFeeInfo = ClaimableFundingFeeInfo.load(
-    transaction.id + ":" + account
+    claimableFundingFeeInfoId
   );
 
-  if (!claimableFundingFeeInfo)
+  if (!claimableFundingFeeInfo) {
+    log.warning("ClaimableFundingFeeInfo not found {}", [
+      claimableFundingFeeInfoId,
+    ]);
+    log.warning("Transaction {}", [transaction.id]);
+    log.warning("Order {}", [order.id]);
     throw new Error("ClaimableFundingFeeInfo not found");
+  }
 
   insertFundingFeeInfo(claimAction, claimableFundingFeeInfo!);
 

--- a/synthetics-stats/src/entities/claims.ts
+++ b/synthetics-stats/src/entities/claims.ts
@@ -66,6 +66,7 @@ export function handleFundingFeeExecutedClaimAction(
     claimableFundingFeeInfoId
   );
 
+  // inconsistent settlement: requested but ClaimableFundingUpdated not emitted
   if (!claimableFundingFeeInfo) {
     return;
   }

--- a/synthetics-stats/src/entities/claims.ts
+++ b/synthetics-stats/src/entities/claims.ts
@@ -66,7 +66,7 @@ export function handleFundingFeeExecutedClaimAction(
     claimableFundingFeeInfoId
   );
 
-  // inconsistent settlement: requested but ClaimableFundingUpdated not emitted
+  // if position has no pending funding fees ClaimableFundingUpdated is not emitted
   if (!claimableFundingFeeInfo) {
     return;
   }

--- a/synthetics-stats/src/entities/claims.ts
+++ b/synthetics-stats/src/entities/claims.ts
@@ -36,10 +36,6 @@ export function handleFundingFeeCreatedClaimAction(
   isLongOrders.push(eventData.getBoolItem("isLong"));
   claimAction.isLongOrders = isLongOrders;
 
-  let transactionIds = claimAction.transactionIds;
-  transactionIds.push(transaction.id);
-  claimAction.transactionIds = transactionIds;
-
   claimAction.save();
 
   getOrCreateClaimRef(orderId);
@@ -78,15 +74,12 @@ export function handleFundingFeeExecutedClaimAction(
   for (let i = 0; i < tokensCount; i++) {
     let marketAddresses = claimAction.marketAddresses;
     let isLongOrders = claimAction.isLongOrders;
-    let transactionIds = claimAction.transactionIds;
 
     marketAddresses.push(order.marketAddress);
     isLongOrders.push(order.isLong);
-    transactionIds.push(transaction.id);
 
     claimAction.marketAddresses = marketAddresses;
     claimAction.isLongOrders = isLongOrders;
-    claimAction.transactionIds = transactionIds;
   }
 
   claimAction.save();
@@ -141,10 +134,6 @@ export function handleFundingFeeCancelledClaimAction(
   let isLongOrders = claimAction.isLongOrders;
   isLongOrders.push(order.isLong);
   claimAction.isLongOrders = isLongOrders;
-
-  let transactionIds = claimAction.transactionIds;
-  transactionIds.push(transaction.id);
-  claimAction.transactionIds = transactionIds;
 
   claimAction.save();
 }
@@ -290,7 +279,6 @@ function getOrCreateClaimAction(id: string): ClaimAction {
     entity.tokenAddresses = new Array<string>(0);
     entity.amounts = new Array<BigInt>(0);
     entity.isLongOrders = new Array<boolean>(0);
-    entity.transactionIds = new Array<string>(0);
   }
 
   return entity as ClaimAction;

--- a/synthetics-stats/src/mapping.ts
+++ b/synthetics-stats/src/mapping.ts
@@ -11,7 +11,6 @@ import {
   isFundingFeeSettleOrder,
   saveClaimableFundingFeeInfo,
   handleCollateralClaimAction,
-  isFundingFeeSettleOrderByOrderId,
   handleFundingFeeCancelledClaimAction,
 } from "./entities/claims";
 import { getIdFromEvent, getOrCreateTransaction } from "./entities/common";

--- a/synthetics-stats/src/mapping.ts
+++ b/synthetics-stats/src/mapping.ts
@@ -11,6 +11,8 @@ import {
   isFundingFeeSettleOrder,
   saveClaimableFundingFeeInfo,
   handleCollateralClaimAction,
+  isFundingFeeSettleOrderByOrderId,
+  handleFundingFeeCancelledClaimAction,
 } from "./entities/claims";
 import { getIdFromEvent, getOrCreateTransaction } from "./entities/common";
 import {
@@ -428,13 +430,18 @@ export function handleEventLog2(event: EventLog2): void {
     let transaction = getOrCreateTransaction(event);
     let order = saveOrderCancelledState(eventData, transaction);
     if (order !== null) {
-      saveOrderCancelledTradeAction(
-        eventId,
-        order as Order,
-        order.cancelledReason as string,
-        order.cancelledReasonBytes as Bytes,
-        transaction
-      );
+      if (isFundingFeeSettleOrder(order!)) {
+        log.warning("order funding fee settle order", [order.id]);
+        handleFundingFeeCancelledClaimAction(transaction, eventData);
+      } else {
+        saveOrderCancelledTradeAction(
+          eventId,
+          order!,
+          order.cancelledReason as string,
+          order.cancelledReasonBytes as Bytes,
+          transaction
+        );
+      }
     }
 
     return;

--- a/synthetics-stats/src/mapping.ts
+++ b/synthetics-stats/src/mapping.ts
@@ -6,7 +6,7 @@ import {
 } from "../generated/EventEmitter/EventEmitter";
 import { ClaimAction, ClaimRef, Order } from "../generated/schema";
 import {
-  handleFundingFeeCreatedClaimAction,
+  saveClaimActionOnOrderCreated,
   handleFundingFeeExecutedClaimAction,
   isFundingFeeSettleOrder,
   saveClaimableFundingFeeInfo,
@@ -373,7 +373,7 @@ export function handleEventLog2(event: EventLog2): void {
     let transaction = getOrCreateTransaction(event);
     let order = saveOrder(eventData, transaction);
     if (isFundingFeeSettleOrder(order)) {
-      handleFundingFeeCreatedClaimAction(transaction, eventData);
+      saveClaimActionOnOrderCreated(transaction, eventData);
     } else {
       saveOrderCreatedTradeAction(eventId, order, transaction);
     }

--- a/synthetics-stats/src/mapping.ts
+++ b/synthetics-stats/src/mapping.ts
@@ -1,4 +1,4 @@
-import { Bytes, log } from "@graphprotocol/graph-ts";
+import { Bytes } from "@graphprotocol/graph-ts";
 import {
   EventLog1,
   EventLog2,
@@ -430,7 +430,6 @@ export function handleEventLog2(event: EventLog2): void {
     let order = saveOrderCancelledState(eventData, transaction);
     if (order !== null) {
       if (isFundingFeeSettleOrder(order!)) {
-        log.warning("order funding fee settle order", [order.id]);
         handleFundingFeeCancelledClaimAction(transaction, eventData);
       } else {
         saveOrderCancelledTradeAction(

--- a/synthetics-stats/src/mapping.ts
+++ b/synthetics-stats/src/mapping.ts
@@ -81,7 +81,6 @@ export function handleEventLog1(event: EventLog1): void {
   if (eventName == "DepositCreated") {
     let transaction = getOrCreateTransaction(event);
     let account = eventData.getAddressItemString("account")!;
-    log.info("DepositCreated xoxo, {}, {}", [eventName, account.toString()]);
     saveUserStat("deposit", account, transaction.timestamp);
     return;
   }
@@ -384,7 +383,6 @@ export function handleEventLog2(event: EventLog2): void {
   if (eventName == "DepositCreated") {
     let transaction = getOrCreateTransaction(event);
     let account = eventData.getAddressItemString("account")!;
-    log.info("DepositCreated xoxo, {}, {}", [eventName, account.toString()]);
     saveUserStat("deposit", account, transaction.timestamp);
     return;
   }

--- a/synthetics-stats/src/mapping.ts
+++ b/synthetics-stats/src/mapping.ts
@@ -4,7 +4,7 @@ import {
   EventLog2,
   EventLogEventDataStruct,
 } from "../generated/EventEmitter/EventEmitter";
-import { ClaimRef, Order } from "../generated/schema";
+import { ClaimAction, ClaimRef, Order } from "../generated/schema";
 import {
   handleFundingFeeCreatedClaimAction,
   handleFundingFeeExecutedClaimAction,
@@ -411,8 +411,7 @@ export function handleEventLog2(event: EventLog2): void {
       order.orderType == orderTypes.get("StopLossDecrease") ||
       order.orderType == orderTypes.get("Liquidation")
     ) {
-      let claimRef = ClaimRef.load(order.id);
-      if (claimRef) {
+      if (ClaimRef.load(order.id)) {
         handleFundingFeeExecutedClaimAction(transaction, eventData);
       } else {
         savePositionDecreaseExecutedTradeAction(
@@ -429,7 +428,7 @@ export function handleEventLog2(event: EventLog2): void {
     let transaction = getOrCreateTransaction(event);
     let order = saveOrderCancelledState(eventData, transaction);
     if (order !== null) {
-      if (isFundingFeeSettleOrder(order!)) {
+      if (ClaimRef.load(order.id)) {
         handleFundingFeeCancelledClaimAction(transaction, eventData);
       } else {
         saveOrderCancelledTradeAction(

--- a/synthetics-stats/src/mapping.ts
+++ b/synthetics-stats/src/mapping.ts
@@ -345,13 +345,13 @@ export function handleEventLog1(event: EventLog1): void {
 
   if (eventName == "FundingFeesClaimed") {
     let transaction = getOrCreateTransaction(event);
-    handleCollateralClaimAction(eventData, transaction, "ClaimFunding");
+    handleCollateralClaimAction("ClaimFunding", eventData, transaction);
     return;
   }
 
   if (eventName == "CollateralClaimed") {
     let transaction = getOrCreateTransaction(event);
-    handleCollateralClaimAction(eventData, transaction, "ClaimPriceImpactFee");
+    handleCollateralClaimAction("ClaimPriceImpactFee", eventData, transaction);
     return;
   }
 

--- a/synthetics-stats/subgraph-arbitrum.yaml
+++ b/synthetics-stats/subgraph-arbitrum.yaml
@@ -1,6 +1,4 @@
 specVersion: 0.0.2
-features:
-  - nonFatalErrors
 description: GMX
 repository: https://github.com/gmx-io/gmx-subgraph
 schema:

--- a/synthetics-stats/subgraph-arbitrum.yaml
+++ b/synthetics-stats/subgraph-arbitrum.yaml
@@ -1,4 +1,6 @@
 specVersion: 0.0.2
+features:
+  - nonFatalErrors
 description: GMX
 repository: https://github.com/gmx-io/gmx-subgraph
 schema:


### PR DESCRIPTION
* `ClaimableFundingFeeInfo` - takes funding fees by ClaimableFundingUpdated event
* `ClaimCollateralAction` is deprecated but is still accumulated
* `ClaimAction` is introduced instead
* Settling represented by 3 new ClaimActionTypes: created, executed and cancelled
* `ClaimRef` is used to group `SettleFundingFeeExecuted` events into one `ClaimAction`


related PR https://github.com/gmx-io/gmx-interface/pull/644