### PR TITLE
context attempt

### DIFF
--- a/synthetics-stats/subgraph-fuji.yaml
+++ b/synthetics-stats/subgraph-fuji.yaml
@@ -8,6 +8,10 @@ dataSources:
   - kind: ethereum/contract
     name: EventEmitter
     network: fuji
+    context:
+      foo:
+        type: Bool
+        data: true
     source:
       address: "0xc67D98AC5803aFD776958622CeEE332A0B2CabB9"
       abi: EventEmitter


### PR DESCRIPTION
trying to add context but getting the following error:

<img width="1150" alt="image" src="https://github.com/gmx-io/gmx-subgraph/assets/144131435/79fa2516-367a-4877-84d8-0b1cbc9da0ce">

it just runs `graph build ./subgraph-fuji.yaml` underhood like we normally do.